### PR TITLE
Fix NGINX Security Hole Properly

### DIFF
--- a/charts/unikorn-common/Chart.yaml
+++ b/charts/unikorn-common/Chart.yaml
@@ -4,6 +4,6 @@ description: Unikorn common templates to keep dependent charts in check.
 
 type: application
 
-version: v0.1.13
+version: v0.1.14
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png

--- a/charts/unikorn-common/templates/_helpers.tpl
+++ b/charts/unikorn-common/templates/_helpers.tpl
@@ -197,10 +197,12 @@ Unified mTLS ingress handling.
 When adding a new provider, you must ensure the verification is optional,
 the UI will not use mTLS for usability, and that the certificate is passed
 in headers to the backend service.
+Please note that all client CAs need to be sourced from the ingress' namespace
+as the controller will reject you being able to access any secret in the system!
 */}}
 {{- define "unikorn.ingress.mtls.annotations" -}}
 nginx.ingress.kubernetes.io/auth-tls-verify-client: optional
-nginx.ingress.kubernetes.io/auth-tls-secret: cert-manager/unikorn-client-ca
+nginx.ingress.kubernetes.io/auth-tls-secret: {{ .Release.Namespace }}/{{ .Release.Namespace }}-client-certificate
 nginx.ingress.kubernetes.io/auth-tls-verify-depth: "1"
 nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
 {{- end }}


### PR DESCRIPTION
Accessing the CA from a shared namespace outside of the current release is banned (by default) by the NGINX ingress controller to prevent it from being able to read every secret on the entire cluster.  You can enable this broken behaviour with `allow-cross-namespace-resources` but being the professionals we are we keep the safe defaults and force every mTLS enabled service to create a client certificate that cert-manager will helpfully populate with a `ca.crt` key.