### PR TITLE
Improve mTLS and Image Pull Secrets

### DIFF
--- a/charts/unikorn-common/Chart.yaml
+++ b/charts/unikorn-common/Chart.yaml
@@ -4,6 +4,6 @@ description: Unikorn common templates to keep dependent charts in check.
 
 type: application
 
-version: v0.1.14
+version: v0.1.15
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png


### PR DESCRIPTION
Make mTLS less hard coded in each dependant helm chart and udefine templates for the secret name, and shared CLI flags.  Add unified image pull secret handling.