### PR TITLE
feat(otlp): add trace sampling ratio to unikorn.otlp.flags helper

### DIFF
--- a/charts/unikorn-common/Chart.yaml
+++ b/charts/unikorn-common/Chart.yaml
@@ -4,6 +4,6 @@ description: Unikorn common templates to keep dependent charts in check.
 
 type: application
 
-version: 0.1.16
+version: 0.1.17
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png

--- a/charts/unikorn-common/templates/_helpers.tpl
+++ b/charts/unikorn-common/templates/_helpers.tpl
@@ -105,6 +105,9 @@ Used to configure tracing across all components.
 {{- with $endpoint := $otlp.endpoint }}
 - --otlp-endpoint={{ $endpoint }}
 {{- end }}
+{{- with $ratio := $otlp.traceSamplingRatio }}
+- --trace-sampling-ratio={{ $ratio }}
+{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Summary

- Adds optional `traceSamplingRatio` field to the `otlp` values block in `unikorn.otlp.flags`
- Services can now set `--trace-sampling-ratio` via Helm values rather than `extraFlags` overrides in cluster config repos
- Bumps chart version to `0.1.17`

## Test plan

- [ ] Set `otlp.traceSamplingRatio: 1.0` in a dependent chart and confirm `--trace-sampling-ratio=1.0` appears in the rendered deployment args
- [ ] Omitting `traceSamplingRatio` should produce no change to existing rendered output