### PR TITLE
feat: add OTLP resource attributes helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,9 @@
 test:
 	helm lint --strict charts/unikorn-common
 	helm template charts/unikorn-common > /dev/null
+	tmp=$$(mktemp -d); \
+	cp -R testdata/otlp-env $$tmp/otlp-env; \
+	perl -0pi -e 's#file://../../charts/unikorn-common#file://$(CURDIR)/charts/unikorn-common#' $$tmp/otlp-env/Chart.yaml; \
+	helm dependency update $$tmp/otlp-env; \
+	helm template $$tmp/otlp-env | grep -q 'name: OTEL_RESOURCE_ATTRIBUTES'; \
+	helm template $$tmp/otlp-env | grep -q 'deployment.environment=dev,service.version=test'

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ test:
 	perl -0pi -e 's#file://../../charts/unikorn-common#file://$(CURDIR)/charts/unikorn-common#' $$tmp/otlp-env/Chart.yaml; \
 	helm dependency update $$tmp/otlp-env; \
 	helm template $$tmp/otlp-env | grep -q 'name: OTEL_RESOURCE_ATTRIBUTES'; \
-	helm template $$tmp/otlp-env | grep -q 'deployment.environment=dev,service.version=test'
+	helm template $$tmp/otlp-env | grep -q 'deployment.environment=test,example.value=east%2Cblue%3Dprimary%25zone,service.version=test'

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ test:
 	perl -0pi -e 's#file://../../charts/unikorn-common#file://$(CURDIR)/charts/unikorn-common#' $$tmp/otlp-env/Chart.yaml; \
 	helm dependency update $$tmp/otlp-env; \
 	helm template $$tmp/otlp-env | grep -q 'name: OTEL_RESOURCE_ATTRIBUTES'; \
-	helm template $$tmp/otlp-env | grep -q 'deployment.environment=test,example.value=east%2Cblue%3Dprimary%25zone,service.version=test'
+	helm template $$tmp/otlp-env | grep -q 'deployment.environment=test,example.value=east%2Cblue%3Dprimary%25zone,service.version=1.2.3%2Bbuild.5'

--- a/charts/unikorn-common/Chart.yaml
+++ b/charts/unikorn-common/Chart.yaml
@@ -4,6 +4,6 @@ description: Unikorn common templates to keep dependent charts in check.
 
 type: application
 
-version: 0.1.17
+version: 0.1.18
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png

--- a/charts/unikorn-common/templates/_helpers.tpl
+++ b/charts/unikorn-common/templates/_helpers.tpl
@@ -112,6 +112,27 @@ Used to configure tracing across all components.
 {{- end }}
 
 {{/*
+OTLP environment variables.
+Used to configure OpenTelemetry SDK resource attributes.
+*/}}
+{{- define "unikorn.otlp.env" -}}
+{{- $otlp := .Values.otlp -}}
+{{- if ( and .Values.global .Values.global.otlp ) -}}
+{{- $otlp = .Values.global.otlp -}}
+{{- end -}}
+{{- if $otlp -}}
+{{- with $attributes := $otlp.resourceAttributes }}
+{{- $pairs := list -}}
+{{- range $key := keys $attributes | sortAlpha -}}
+{{- $pairs = append $pairs (printf "%s=%v" $key (index $attributes $key)) -}}
+{{- end }}
+- name: OTEL_RESOURCE_ATTRIBUTES
+  value: {{ join "," $pairs | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 CORS support.
 Used to lock down APIs to specific clients.
 */}}

--- a/charts/unikorn-common/templates/_helpers.tpl
+++ b/charts/unikorn-common/templates/_helpers.tpl
@@ -115,6 +115,10 @@ Used to configure tracing across all components.
 OTLP environment variables.
 Used to configure OpenTelemetry SDK resource attributes.
 */}}
+{{- define "unikorn.otlp.resourceAttribute.escape" -}}
+{{- . | toString | replace "%" "%25" | replace "," "%2C" | replace "=" "%3D" -}}
+{{- end }}
+
 {{- define "unikorn.otlp.env" -}}
 {{- $otlp := .Values.otlp -}}
 {{- if ( and .Values.global .Values.global.otlp ) -}}
@@ -124,7 +128,9 @@ Used to configure OpenTelemetry SDK resource attributes.
 {{- with $attributes := $otlp.resourceAttributes }}
 {{- $pairs := list -}}
 {{- range $key := keys $attributes | sortAlpha -}}
-{{- $pairs = append $pairs (printf "%s=%v" $key (index $attributes $key)) -}}
+{{- $encodedKey := include "unikorn.otlp.resourceAttribute.escape" $key -}}
+{{- $encodedValue := include "unikorn.otlp.resourceAttribute.escape" (index $attributes $key) -}}
+{{- $pairs = append $pairs (printf "%s=%s" $encodedKey $encodedValue) -}}
 {{- end }}
 - name: OTEL_RESOURCE_ATTRIBUTES
   value: {{ join "," $pairs | quote }}

--- a/charts/unikorn-common/templates/_helpers.tpl
+++ b/charts/unikorn-common/templates/_helpers.tpl
@@ -116,7 +116,7 @@ OTLP environment variables.
 Used to configure OpenTelemetry SDK resource attributes.
 */}}
 {{- define "unikorn.otlp.resourceAttribute.escape" -}}
-{{- . | toString | replace "%" "%25" | replace "," "%2C" | replace "=" "%3D" -}}
+{{- . | toString | urlquery -}}
 {{- end }}
 
 {{- define "unikorn.otlp.env" -}}

--- a/charts/unikorn-common/values.yaml
+++ b/charts/unikorn-common/values.yaml
@@ -1,1 +1,4 @@
-# Intentionally empty.
+# global:
+#   otlp:
+#     resourceAttributes:
+#       deployment.environment: dev

--- a/testdata/otlp-env/Chart.yaml
+++ b/testdata/otlp-env/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: otlp-env-fixture
+description: Test fixture for rendering common OTLP environment helpers.
+type: application
+version: 0.0.0
+
+dependencies:
+- name: unikorn-common
+  version: 0.1.18
+  repository: file://../../charts/unikorn-common

--- a/testdata/otlp-env/templates/pod.yaml
+++ b/testdata/otlp-env/templates/pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}-otlp-env
+spec:
+  containers:
+  - name: app
+    image: ghcr.io/nscaledev/otlp-env-fixture:latest
+    env:
+    {{- include "unikorn.otlp.env" . | nindent 4 }}

--- a/testdata/otlp-env/values.yaml
+++ b/testdata/otlp-env/values.yaml
@@ -1,5 +1,6 @@
 global:
   otlp:
     resourceAttributes:
-      deployment.environment: dev
+      deployment.environment: test
+      example.value: east,blue=primary%zone
       service.version: test

--- a/testdata/otlp-env/values.yaml
+++ b/testdata/otlp-env/values.yaml
@@ -3,4 +3,4 @@ global:
     resourceAttributes:
       deployment.environment: test
       example.value: east,blue=primary%zone
-      service.version: test
+      service.version: 1.2.3+build.5

--- a/testdata/otlp-env/values.yaml
+++ b/testdata/otlp-env/values.yaml
@@ -1,0 +1,5 @@
+global:
+  otlp:
+    resourceAttributes:
+      deployment.environment: dev
+      service.version: test


### PR DESCRIPTION
## Summary

Adds a shared `unikorn.otlp.env` helper that renders `OTEL_RESOURCE_ATTRIBUTES` from `otlp.resourceAttributes` / `global.otlp.resourceAttributes`.

This lets UNI component charts attach app-level OpenTelemetry resource attributes such as `deployment.environment` to emitted spans without duplicating env-var rendering in each chart. Attribute keys and values are URL/query escaped before they are joined into the OTEL comma-separated env-var format.

## Current status

This PR is **not required** for the current `Uni / API Health` dashboard environment filter.

The live dashboard path is now:

- Tempo exposes the collector-provided `environment` resource attribute as a span-metrics dimension.
- `Uni / API Health` filters Prometheus span metrics with `environment=~"${environment:raw}"`.
- Dev and staging data have been verified in live Mimir through that `environment` label.

This PR remains useful as a future/app-level semantic-convention cleanup so UNI services can emit `deployment.environment` and any other resource attributes themselves, instead of relying only on collector-added `environment`.

Dashboard: https://observability-grafana.nscale.teleport.sh/d/uni-api-health/uni-api-health

## Validation

- `git diff --check`
- `make test`
- Rendered fixture includes encoded attributes, including `+` as `%2B`:
  - `deployment.environment=test,example.value=east%2Cblue%3Dprimary%25zone,service.version=1.2.3%2Bbuild.5`
- GitHub checks passing:
  - `Test Helm Template`
  - `Analyze (actions)`
  - `CodeQL`
- Latest commit `5bbfb3c` is signed and GitHub-verified.

## Rollout

Merging this PR publishes `unikorn-common` `0.1.18`.

Downstream component chart PRs should only consume `0.1.18` if/when we decide to continue the separate app-emitted `deployment.environment` rollout. They are not needed for the current dashboard fix.

This PR does not fix prod dashboard data. Prod data depends on the live prod `aoa-deploy-unikorn` Application picking up `traceSamplingRatio: 1.0`.